### PR TITLE
Make textarea bigger

### DIFF
--- a/classes/class.ilGuidedTourConfigGUI.php
+++ b/classes/class.ilGuidedTourConfigGUI.php
@@ -290,6 +290,7 @@ class ilGuidedTourConfigGUI extends ilPluginConfigGUI
         $script = new ilTextAreaInputGUI($plugin->txt('tour_script'), 'script');
         $script->setInfo($plugin->txt('tour_script_info'));
         $script->setValue($tour->getScript());
+        $script->setRows(20);
         $form->addItem($script);
 
         // command buttons


### PR DESCRIPTION
Hey @nstaszak 
I would like to add a little improvement for the textarea where the JSON is written. By default, the textarea is like two rows and I always have to expand it with the mouse when editing the JSON. Giving it e.g. 20 rows simplifies the work.